### PR TITLE
107 complete profile

### DIFF
--- a/src/app/api/events/[eventID]/registrations/route.ts
+++ b/src/app/api/events/[eventID]/registrations/route.ts
@@ -61,7 +61,6 @@ export async function PUT(req: NextRequest, { params }: { params: { eventID: str
   }
 
   // Validate profile completeness
-
   if (attendees.includes(mongoUserId) && !isUserProfileComplete(user)) {
     return NextResponse.json({ error: "Your profile is incomplete." }, { status: 409 });
   }

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -1,8 +1,26 @@
 "use client";
 
 import PersonalInfo from "@/components/UserComponent/PersonalInfo";
+import { useEffect } from "react";
+import { useToast } from "@/hooks/use-toast";
 
 export default function UserProfile() {
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const shouldShowToast = localStorage.getItem("showProfileIncompleteToast");
+    console.log(shouldShowToast);
+
+    if (shouldShowToast) {
+      toast({
+        title: "Profile Incomplete",
+        description: "Please complete your profile(s) to sign a waiver or register.",
+        variant: "destructive",
+      });
+      localStorage.removeItem("showProfileIncompleteToast");
+    }
+  }, []);
+
   return (
     <main>
       <PersonalInfo></PersonalInfo>

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -14,7 +14,7 @@ export default function UserProfile() {
     if (shouldShowToast) {
       toast({
         title: "Profile Incomplete",
-        description: "Please complete your profile(s) to sign a waiver or register.",
+        description: "Please complete all required profile fields before registering for events or signing waivers.",
         variant: "destructive",
       });
       localStorage.removeItem("showProfileIncompleteToast");

--- a/src/components/EventComponent/EventInfoPreview.tsx
+++ b/src/components/EventComponent/EventInfoPreview.tsx
@@ -211,6 +211,14 @@ export function EventInfoPreview({
         });
 
         const responseData = await response.json();
+
+        if (response.status === 409) {
+          console.error("Profile incomplete:", responseData.error);
+          localStorage.setItem("showProfileIncompleteToast", "true");
+
+          router.push("/user");
+        }
+
         if (!response.ok) throw new Error(responseData.error || "Failed to register for event.");
 
         setIsRegistered(true);

--- a/src/components/WaiverSignatureComponent/SignatureCanvas.tsx
+++ b/src/components/WaiverSignatureComponent/SignatureCanvas.tsx
@@ -80,6 +80,17 @@ function SignatureCanvas({ eventId, waiverId, fileKey, participants, onSigned }:
 
         const result = await res.json();
 
+        if (res.status === 409) {
+          try {
+            console.error("Profile incomplete:", result.error);
+          } catch {
+            console.error("Profile incomplete: invalid JSON response.");
+          }
+          localStorage.setItem("showProfileIncompleteToast", "true");
+
+          router.push("/user");
+        }
+
         if (res.ok) {
           setSuccessMsg("Waiver signed successfully!");
           //console.log("Signed PDF URL:", result.signedPdfUrl);
@@ -88,6 +99,7 @@ function SignatureCanvas({ eventId, waiverId, fileKey, participants, onSigned }:
         } else {
           console.error(result.error);
           setSuccessMsg(`Error: ${result.error}`);
+          throw new Error(result.error || "Failed to register for event.");
         }
       } catch (err) {
         console.error("Error saving signature:", err);

--- a/src/lib/validate.ts
+++ b/src/lib/validate.ts
@@ -1,0 +1,39 @@
+function isEmergencyContactComplete(contact: EmergencyContact): boolean {
+  return !!(contact.name && contact.phone && contact.relationship);
+}
+
+function hasCompleteEmergencyContact(contacts: EmergencyContact[]): boolean {
+  return Array.isArray(contacts) && contacts.some(isEmergencyContactComplete);
+}
+
+function isAddressComplete(address?: IUser["address"]): boolean {
+  return !!(address?.home && address.city && address.zipCode);
+}
+
+function isMedicalInfoComplete(medicalInfo: MedicalInfo): boolean {
+  return medicalInfo?.photoRelease !== undefined;
+}
+
+export function isUserProfileComplete(user: IUser): boolean {
+  return (
+    !!user.firstName &&
+    !!user.lastName &&
+    !!user.email &&
+    !!user.gender &&
+    !!user.birthday &&
+    isAddressComplete(user.address) &&
+    isMedicalInfoComplete(user.medicalInfo) &&
+    hasCompleteEmergencyContact(user.emergencyContacts)
+  );
+}
+
+export function isChildProfileComplete(child: IChild): boolean {
+  return (
+    !!child.firstName &&
+    !!child.lastName &&
+    !!child.gender &&
+    !!child.birthday &&
+    isMedicalInfoComplete(child.medicalInfo) &&
+    hasCompleteEmergencyContact(child.emergencyContacts)
+  );
+}


### PR DESCRIPTION
## Developer: Angela Chen

Closes #107

### Pull Request Summary

Checks if profile is complete when signing waiver/registering - if not, redirect to /user and display a toast to complete profile.

### Modifications
@/lib/validate.ts - helper validation functions
src/app/user/page.tsx - to display toast
eventInfoPreview, SignatureCanver, WaiverSignatureForm components - client-side redirect
api/events/[eventID]/waivers AND api/events/[eventID]/registrations - server side validation


### Testing Considerations

I tested signing/registering with complete/incomplete profile, and incomplete children profiles (have not tested w complete child profile yet). I also tried for events w no waivers and events w waivers.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
